### PR TITLE
Fixed broken troop count when support is in the village + minor fix

### DIFF
--- a/core/extractors.py
+++ b/core/extractors.py
@@ -104,9 +104,14 @@ class Extractor:
     def units_in_village(res):
         if type(res) != str:
             res = res.text
-        res = re.sub('(?s)<table id="units_home".+?</table>', '', res)
-        data = re.findall(r'(?s)<a href="#" class="unit_link" data-unit="(\w+)".+?(\d+)</strong>', res)
-        return data
+        matches = re.search(r'<td>From this village</td>(.*?)</tr>', res, re.DOTALL) #We get the row saying "From this village", until the row is over (</tr>)
+        if matches:
+            table_content = matches.group(1)
+            unit_matches = re.findall(r'class=\'unit-item unit-item-(.*?)\'[^>]*>(\d+)</td>', table_content) #Find all the tuples (name, quantity) under the class "unit-item unit-item-*troop_name*"
+            units = [(re.sub(r'\s*tooltip\s*', '', unit_name), unit_quantity) for unit_name, unit_quantity in unit_matches if int(unit_quantity) > 0] #Filter units with quantity = 0, also for the Paladin, the name would be "knight tooltip", so we had to remove that.
+            return units
+        else:
+            return []
 
     @staticmethod
     def active_building_queue(res):

--- a/core/extractors.py
+++ b/core/extractors.py
@@ -104,7 +104,7 @@ class Extractor:
     def units_in_village(res):
         if type(res) != str:
             res = res.text
-        matches = re.search(r'<td>From this village</td>(.*?)</tr>', res, re.DOTALL) #We get the row saying "From this village", until the row is over (</tr>)
+        matches = re.search(r'<table id="units_home".*?</tr>(.*?)</tr>', res, re.DOTALL) #We get the start of the table and grab the 2nd row (Where "From this village" troops are located)
         if matches:
             table_content = matches.group(1)
             unit_matches = re.findall(r'class=\'unit-item unit-item-(.*?)\'[^>]*>(\d+)</td>', table_content) #Find all the tuples (name, quantity) under the class "unit-item unit-item-*troop_name*"

--- a/game/troopmanager.py
+++ b/game/troopmanager.py
@@ -82,7 +82,14 @@ class TroopManager:
                 "Recruitment: %s" % self.game_data["village"]["name"]
             )
         self.troops = {}
-        for u in Extractor.units_in_village(main_data):
+
+        get_all = (
+            "game.php?village=%s&screen=place&mode=units&display=units"
+            % self.village_id
+        )
+        result_all = self.wrapper.get_url(get_all)
+
+        for u in Extractor.units_in_village(result_all):
             k, v = u
             self.troops[k] = v
 
@@ -91,11 +98,6 @@ class TroopManager:
         if not self.can_recruit:
             return
 
-        get_all = (
-            "game.php?village=%s&screen=place&mode=units&display=units"
-            % self.village_id
-        )
-        result_all = self.wrapper.get_url(get_all)
         self.total_troops = {}
         for u in Extractor.units_in_total(result_all):
             k, v = u
@@ -336,6 +338,18 @@ class TroopManager:
 
         sleep = 0
         available_selection = 0
+
+        self.troops = {}
+
+        get_all = (
+            "game.php?village=%s&screen=place&mode=units&display=units"
+            % self.village_id
+        )
+        result_all = self.wrapper.get_url(get_all)
+
+        for u in Extractor.units_in_village(result_all):
+            k, v = u
+            self.troops[k] = v
 
         troops = dict(self.troops)
 


### PR DESCRIPTION
Changed units_in_village(), so that the data taken is only about the units "From this village" as the name suggests. 

Data fetched comes from the rally point page, so instead of initializing a new variable I simply moved up "get_all", and used "result_all" to get the data needed.

Since many times the scavenging would be done while the bot was running farms, I also added another troop check once scavenging begins.